### PR TITLE
Add point-in-volume test to faceter test case

### DIFF
--- a/src/test/test_faceter.cc
+++ b/src/test/test_faceter.cc
@@ -4,6 +4,8 @@
 #include "read_metadata.hh"
 #include "BRep_Builder.hxx"
 #include "BRepTools.hxx"
+#include "moab/GeomQueryTool.hpp"
+#include "moab/GeomTopoTool.hpp"
 
 TEST_CASE("Faceting BREP and writing to MOAB", "[faceter]") {
 
@@ -35,4 +37,43 @@ TEST_CASE("Faceting BREP and writing to MOAB", "[faceter]") {
   REQUIRE(triangles.size() == 22);
 
   mbtool.write_geometry(output_path);
+
+  // pt_in_vol and ray_file tests
+
+  moab::Core mbi;
+  ret = mbi.load_file(output_path);
+  REQUIRE(ret == moab::MB_SUCCESS);
+
+  moab::GeomTopoTool gtt(&mbi);
+  moab::GeomQueryTool gqt(&gtt);
+  ret = gqt.initialize();
+  REQUIRE(ret == moab::MB_SUCCESS);
+
+  int dim = 3;
+  moab::EntityHandle vol1 = gqt.gttool()->entity_by_id(dim, 1);
+  moab::EntityHandle vol2 = gqt.gttool()->entity_by_id(dim, 2);
+
+  int result = 0;
+  double xyz[3] = {1.0, 1.0, 1.0};
+  ret = gqt.point_in_volume(vol1, xyz, result);
+  REQUIRE(ret == moab::MB_SUCCESS);
+  REQUIRE(result == 1);
+
+  ret = gqt.point_in_volume(vol2, xyz, result);
+  REQUIRE(ret == moab::MB_SUCCESS);
+  REQUIRE(result == 0);
+
+  xyz[0] = 11;
+  result = 0;
+  ret = gqt.point_in_volume(vol2, xyz, result);
+  REQUIRE(ret == moab::MB_SUCCESS);
+  REQUIRE(result == 1);
+
+  double start[3] = {1.0, 1.0, 1.0};
+  double next_surf_dist;
+  moab::EntityHandle next_surf;
+  double dir[3] = {-1.0, 0.0, 0.0};
+  ret = gqt.ray_fire(vol1, start, dir, next_surf, next_surf_dist);
+  REQUIRE(ret == moab::MB_SUCCESS);
+  REQUIRE(next_surf_dist == 1.0);
 }


### PR DESCRIPTION
Previously, the test was simply checking that the faceting completed successfully and generated the expected number of triangles.  This extends the test with a couple of basic point-in-volume and ray-fire checks.