### PR TITLE
Reduce noise in stdout

### DIFF
--- a/src/MBTool.cpp
+++ b/src/MBTool.cpp
@@ -23,6 +23,7 @@ MBTool::MBTool() {
     volID = 0;
     surfID = 0;
     curveID = 0;
+    degenerate_triangle_count = 0;
     existing_vertices.clear();
     // make a new meshset to put stuff in
     moab::ErrorCode rval = mbi->create_meshset(moab::MESHSET_SET, rootset);
@@ -251,7 +252,7 @@ moab::ErrorCode MBTool::add_facets_and_curves_to_surface(moab::EntityHandle surf
      if ( connections[2] == connections[1] || 
           connections[1] == connections[0] || 
           connections[2] == connections[0] ) {
-       std::cout << "degenerate triangle not created" << std::endl;
+       degenerate_triangle_count++;
      } else {
        moab::ErrorCode rval = mbi->create_element(moab::MBTRI,connections,3,tri);
        triangles.insert(tri);
@@ -315,7 +316,11 @@ moab::ErrorCode MBTool::add_facets_and_curves_to_surface(moab::EntityHandle surf
 // write the geometry
 void MBTool::write_geometry(std::string filename) {
   moab::ErrorCode rval = mbi->write_file(filename.c_str());
-  return;
+
+  if (degenerate_triangle_count > 0) {
+    std::cout << "Warning: " << degenerate_triangle_count
+      << " degenerate triangles have been ignored." << std::endl;
+  }
 }
 
 void summarise() {

--- a/src/MBTool.hpp
+++ b/src/MBTool.hpp
@@ -67,6 +67,7 @@ private:
   int volID;
   int surfID;
   int curveID;
+  int degenerate_triangle_count;
   moab::EntityHandle rootset;
   moab::Tag geometry_dimension_tag, id_tag;
   moab::Tag faceting_tol_tag, geometry_resabs_tag;
@@ -75,6 +76,5 @@ private:
   moab::Tag name_tag;
   moab::Tag mat_id_tag;
   moab::Range existing_vertices;
-
 };
 #endif // MBTOOL_HPP


### PR DESCRIPTION
Instead of warning everytime a degenerate triangle is found, or when a surface doesn't have any facets, occ_faceter now reports a summary of how many degenerate triangles and surfaces without facets were found.

(I'll look into how to ignore whitespace in the diff, because this is making it tricky to see what has changed.)