### PR TITLE
ignore build dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 *.txt
 *.stp
 *.h5m
+# build dir
+build
+bld


### PR DESCRIPTION
A build dir will be generated and tracked according to the install guide. This PR just ignore the build dir.